### PR TITLE
Fix docs API description

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ exhale_args = {
     "rootFileName":          "library_root.rst",
     "doxygenStripFromPath":  "..",
     "rootFileTitle":         "Trossen Arm Driver API",
-    "createTreeView":        False,
+    "createTreeView":        True,
     "exhaleExecutesDoxygen": True,
     "afterTitleDescription": """
 .. note::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,20 +142,17 @@ breathe_default_project = 'Trossen Arm API Documentation'
 
 # Setup the exhale extension
 exhale_args = {
-    # These arguments are required
     "containmentFolder":     "./api",
     "rootFileName":          "library_root.rst",
     "doxygenStripFromPath":  "..",
-    # Heavily encouraged optional argument (see docs)
     "rootFileTitle":         "Trossen Arm Driver API",
-    # Suggested optional arguments
-    "createTreeView":        True,
+    "createTreeView":        False,
     "exhaleExecutesDoxygen": True,
     "afterTitleDescription": """
 .. note::
 
     These API docs are generated based on the C++ library.
-    The Python package is not explicitly documented due to its similarity with the C++ API.
+    The Python package is not explicitly documented due to its similarity to the C++ API.
 """,
     "exhaleDoxygenStdin":    """
     PROJECT_NAME           = "Trossen Arm API Documentation"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ What's Here
 *   :doc:`downloads` - Downloadable content related to the Trossen Arm.
 *   :doc:`troubleshooting` - Common issues and their solutions.
 *   :doc:`changelog` - Changes and updates to the Trossen Arm software.
-*   :doc:`api/library_root` - Trossen Arm C++ API.
+*   :doc:`api/library_root` - Trossen Arm API documentation.
 
 Table of Contents:
 ==================


### PR DESCRIPTION
This PR fixes the description of the API documentation, removing the explicit mention of C++ since the API docs are for both C++ and Python. Minor cleanup and grammar.