### PR TITLE
Add wxai assembly videos to hardware setup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,13 +16,14 @@ copyright = "{}, {}".format(time.strftime("%Y"), author)
 extensions = [
     'breathe',
     'exhale',
-    'sphinxcontrib.mermaid',
     'sphinx_copybutton',
     'sphinx_multiversion',
     'sphinx_tabs.tabs',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.extlinks',
     'sphinx.ext.githubpages',
+    'sphinxcontrib.mermaid',
+    'sphinxcontrib.youtube',
 ]
 
 # Enable AutoSectionLabel

--- a/docs/getting_started/hardware_setup.rst
+++ b/docs/getting_started/hardware_setup.rst
@@ -7,11 +7,27 @@ This section walks you through the hardware setup for a new Trossen Arm.
 Assembly
 ========
 
-Download the assembly guide for your arm model and variant from the options below:
+Download the assembly guide or watch the YouTube video for your arm model and variant from the options below:
 
--  :download:`WidowX AI Base Assembly Guide </_downloads/WidowX AI Base Assembly Guide.pdf>`
--  :download:`WidowX AI Leader Assembly Guide </_downloads/WidowX AI Leader Assembly Guide.pdf>`
--  :download:`WidowX AI Follower Assembly Guide </_downloads/WidowX AI Follower Assembly Guide.pdf>`
+.. list-table::
+    :align: center
+    :header-rows: 1
+
+    * - WidowX AI Base
+      - WidowX AI Leader
+      - WidowX AI Follower
+    * - :download:`WidowX AI Base Assembly Guide </_downloads/WidowX AI Base Assembly Guide.pdf>`
+      - :download:`WidowX AI Leader Assembly Guide </_downloads/WidowX AI Leader Assembly Guide.pdf>`
+      - :download:`WidowX AI Follower Assembly Guide </_downloads/WidowX AI Follower Assembly Guide.pdf>`
+    * - .. youtube:: BDlKgnniVJ8
+          :align: center
+          :width: 300px
+      - .. youtube:: hdPAw-pwMm4
+          :align: center
+          :width: 300px
+      - .. youtube:: w5s9EzMBmsU
+          :align: center
+          :width: 300px
 
 .. warning::
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,8 +3,9 @@ docutils
 exhale
 pip
 sphinx
-sphinxcontrib-mermaid
 sphinx-copybutton
 sphinx-multiversion
 sphinx-rtd-theme
 sphinx-tabs
+sphinxcontrib-mermaid
+sphinxcontrib-youtube


### PR DESCRIPTION
This PR adds WidowX AI assembly videos to the hardware setup page.

![image](https://github.com/user-attachments/assets/b7077fa8-6c5e-448f-a760-ec88fee6459d)
