### PR TITLE
Document gripper continuity factor disabling method

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -279,7 +279,6 @@ continuity_factors
 
 The arm controller uses this factor to determine whether the commanded joint position is continuous.
 If not, the controller enter the :ref:`troubleshooting:16: robot input discontinuous` error state.
-The gripper joint has an option to disable the continuity check by setting its factor to a negative value.
 
 Default value: ``5.0``
 
@@ -292,6 +291,15 @@ Range: :math:`[1.0, 10.0]`
     - check that the frequency of the control loop is at least 300 Hz if the built-in interpolator is disabled, i.e., the ``goal_time`` is zero
     - otherwise, check that the ``goal_time`` is long enough compared to looping time so that the joint can feasibly reach ``goal_position`` within ``goal_time``
     - finally, if you're confident that there's no implementation mistake in the script, increase the continuity factor with discretion
+
+.. note::
+
+    The gripper joint has an option to disable the continuity check by setting its factor to a negative value.
+
+    .. warning::
+
+        This is a potentially dangerous option as it allows users to command positions to the gripper that far exceed the physical limits.
+        Please use it with caution.
 
 End Effector
 ------------

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -279,7 +279,7 @@ continuity_factors
 
 The arm controller uses this factor to determine whether the commanded joint position is continuous.
 If not, the controller enter the :ref:`troubleshooting:16: robot input discontinuous` error state.
-The gripper joint has an option to disable the continuity check by setting the factor to a negative value.
+The gripper joint has an option to disable the continuity check by setting its factor to a negative value.
 
 Default value: ``5.0``
 

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -279,6 +279,7 @@ continuity_factors
 
 The arm controller uses this factor to determine whether the commanded joint position is continuous.
 If not, the controller enter the :ref:`troubleshooting:16: robot input discontinuous` error state.
+The gripper joint has an option to disable the continuity check by setting the factor to a negative value.
 
 Default value: ``5.0``
 


### PR DESCRIPTION
This PR documents the option to disable continuity enforcement on the gripper joint.