### PR TITLE
Add av build dependency installation to UI guide

### DIFF
--- a/docs/tutorials/lerobot/setup.rst
+++ b/docs/tutorials/lerobot/setup.rst
@@ -33,11 +33,22 @@ On your computer:
    .. note::
 
     If you encounter build errors, you may need to install additional dependencies ``cmake``, ``build-essential``, and ``ffmpeg libs``.
-    On Linux, run: 
-    
+    On Linux, run:
+
     .. code-block::
-      
-      sudo apt-get install cmake build-essential python3-dev pkg-config libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev pkg-config
+
+      sudo apt-get install -y \
+         build-essential \
+         cmake \
+         libavcodec-dev \
+         libavdevice-dev \
+         libavfilter-dev \
+         libavformat-dev \
+         libavutil-dev \
+         libswresample-dev \
+         libswscale-dev \
+         pkg-config \
+         python3-dev
 
     For other systems, see: `Compiling PyAV <https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg>`_
 
@@ -49,20 +60,20 @@ On your computer:
 
 
    .. note::
-      
-      Installing ``ffmpeg>=7.0`` using the above command usually provides ``ffmpeg 7.X`` compiled with the ``libsvtav1`` encoder.  
+
+      Installing ``ffmpeg>=7.0`` using the above command usually provides ``ffmpeg 7.X`` compiled with the ``libsvtav1`` encoder.
       If ``libsvtav1`` is **not** available on your system (you can verify by running ``ffmpeg -encoders``), you have two options:
 
       - **Any platform**: Install a specific version of FFmpeg with conda:
-         
+
          .. code-block:: bash
 
             conda install ffmpeg=7.1.1 -c conda-forge
 
-      - **Linux only**: Manually install FFmpeg build dependencies and compile FFmpeg from source with `libsvtav1` support:  
+      - **Linux only**: Manually install FFmpeg build dependencies and compile FFmpeg from source with `libsvtav1` support:
          Refer to the official guides below:
-         
-         - `FFmpeg build dependencies <https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu#GettheDependencies>`_  
+
+         - `FFmpeg build dependencies <https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu#GettheDependencies>`_
          - `Compile FFmpeg with libsvtav1 <https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu#libsvtav1>`_
 
       After installation, confirm you're using the correct FFmpeg binary with:

--- a/docs/tutorials/lerobot/setup.rst
+++ b/docs/tutorials/lerobot/setup.rst
@@ -32,25 +32,25 @@ On your computer:
 
    .. note::
 
-    If you encounter build errors, you may need to install additional dependencies ``cmake``, ``build-essential``, and ``ffmpeg libs``.
-    On Linux, run:
+      If you encounter build errors, you may need to install additional dependencies ``cmake``, ``build-essential``, and ``ffmpeg libs``.
+      On Linux, run:
 
-    .. code-block::
+      .. code-block::
 
-      sudo apt-get install -y \
-         build-essential \
-         cmake \
-         libavcodec-dev \
-         libavdevice-dev \
-         libavfilter-dev \
-         libavformat-dev \
-         libavutil-dev \
-         libswresample-dev \
-         libswscale-dev \
-         pkg-config \
-         python3-dev
+         sudo apt-get install -y \
+            build-essential \
+            cmake \
+            libavcodec-dev \
+            libavdevice-dev \
+            libavfilter-dev \
+            libavformat-dev \
+            libavutil-dev \
+            libswresample-dev \
+            libswscale-dev \
+            pkg-config \
+            python3-dev
 
-    For other systems, see: `Compiling PyAV <https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg>`_
+      For other systems, see: `Compiling PyAV <https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg>`_.
 
 #. For Linux only (not Mac), install extra dependencies for recording datasets:
 

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -73,6 +73,10 @@ Once the pre-installation setup is complete, install the **Trossen AI Data Colle
 
         pip install trossen_ai_data_collection_ui
 
+    .. note::
+
+        The command above requires sudo privileges and may prompt you for your password.
+
 Post-Installation
 =================
 

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -27,18 +27,18 @@ Before installing the application, complete the following setup steps:
 #. Create a Virtual Environment:
 
    Use Miniconda to create and activate a virtual environment to ensure a clean setup for the application:
-   
+
    .. code-block:: bash
-      
+
       conda create -n trossen_ai_data_collection_ui_env python=3.10 -y
       conda activate trossen_ai_data_collection_ui_env
 
 #. Verify Python Version:
 
    Ensure that Python 3.10 is activated in the environment by running:
-   
+
    .. code-block:: bash
-      
+
       python --version
 
    You should see ``Python 3.10.x`` as the output.
@@ -48,9 +48,28 @@ Installation
 
 Once the pre-installation setup is complete, install the **Trossen AI Data Collection UI Application**.
 
-.. code-block:: bash
+#. Install build dependencies on Linux:
 
-    pip install trossen_ai_data_collection_ui
+    .. code-block:: bash
+
+        sudo apt-get install -y \
+            build-essential \
+            cmake \
+            libavcodec-dev \
+            libavdevice-dev \
+            libavfilter-dev \
+            libavformat-dev \
+            libavutil-dev \
+            libswresample-dev \
+            libswscale-dev \
+            pkg-config \
+            python3-dev
+
+#.  Run the post-installation script to install the application
+
+    .. code-block:: bash
+
+        pip install trossen_ai_data_collection_ui
 
 Post-Installation
 =================
@@ -66,7 +85,7 @@ The post-installation script sets up additional configurations, including:
 Run the following command to complete the post-installation setup:
 
 .. code-block:: bash
-    
+
     trossen_ai_data_collection_ui_post_install
 
 Once the desktop icon is created, right-click on it and select **Allow Launching** to ensure the application has the necessary permissions to run.
@@ -126,7 +145,7 @@ The Trossen AI Data Collection UI offers a variety of features designed to simpl
 
 #. Camera Views
 
-    - Live Camera Feeds: You can view multiple camera angles at once while recording, making it easy to monitor the robotic arms and their surroundings as things happen. 
+    - Live Camera Feeds: You can view multiple camera angles at once while recording, making it easy to monitor the robotic arms and their surroundings as things happen.
 
 #. Configuration Management
 

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -65,6 +65,8 @@ Once the pre-installation setup is complete, install the **Trossen AI Data Colle
             pkg-config \
             python3-dev
 
+    For other systems, see: `Compiling PyAV <https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg>`_.
+
 #.  Run the post-installation script to install the application
 
     .. code-block:: bash

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -67,7 +67,7 @@ Once the pre-installation setup is complete, install the **Trossen AI Data Colle
 
     For other systems, see: `Compiling PyAV <https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg>`_.
 
-#.  Run the post-installation script to install the application
+#.  Run the post-installation script to install the application:
 
     .. code-block:: bash
 

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -48,7 +48,7 @@ Installation
 
 Once the pre-installation setup is complete, install the **Trossen AI Data Collection UI Application**.
 
-#. Install build dependencies on Linux:
+#.  Install build dependencies on Linux:
 
     .. code-block:: bash
 


### PR DESCRIPTION
This PR does the following:
* Adds the lerobot build dependency installation to the data collection UI guide
* Fixes some formatting on the lerobot and data collection ui installation guides