### PR TITLE
[documentation] Lerobot:  motion timing config and leader arm deactivation

### DIFF
--- a/docs/tutorials/lerobot/changelog.rst
+++ b/docs/tutorials/lerobot/changelog.rst
@@ -4,10 +4,52 @@ Updates & Changelog
 
 This page documents major updates to the project, such as changes to dataset formats, codebase improvements, new features, and compatibility notes.
 
+Leader Arm Deactivation During Inference
+========================================
+
+:date: 05-01-2025
+:commit: `Interbotix/lerobot@3413f52 <https://github.com/Interbotix/lerobot/commit/3413f525536aa995b1a0a6e32046f27c603b6f87>`_
+
+
+Leader arms are now automatically disabled during evaluation when a policy is present and replay.
+This ensures that only the follower arms are active during inference, improving safety and reducing unnecessary resource usage.
+
+Configurable Motion Timing
+==========================
+
+:date: 06-27-2025
+:commit: `Interbotix/lerobot@64cd0c9 <https://github.com/Interbotix/lerobot/commit/64cd0c919ab5380656eaacc76dc3331958ba0d78>`_
+
+
+Introduced min_time_to_move_multiplier as a configurable parameter.
+This allows users to control the time taken for the robot arm to reach a goal position via:
+`min_time_to_move = multiplier / fps`.
+
+A CLI argument can now be passed to adjust motion smoothness:
+
+.. code-block:: bash
+
+    python lerobot/scripts/control_robot.py \
+           --robot.type=trossen_ai_mobile \
+           --control.type=record \
+           --control.fps=30 \
+           --control.single_task="Recording evaluation episode using Trossen AI Mobile." \
+           --control.repo_id=${HF_USER}/eval_act_trossen_ai_mobile_test \
+           --control.tags='["tutorial"]' \
+           --control.warmup_time_s=5 \
+           --control.episode_time_s=30 \
+           --control.reset_time_s=30 \
+           --control.num_episodes=10 \
+           --control.push_to_hub=true \
+           --control.policy.path=outputs/train/act_trossen_ai_mobile_test/checkpoints/last/pretrained_model \
+           --control.num_image_writer_processes=1 \
+           --robot.enable_motor_torque=true \
+           --robot.min_time_to_move_multiplier=6.0
+
 Trossen v1.0 Dataset Format
 ===========================
 
-:date: 05-01-2025
+:date: 06-27-2025
 :commit: `Interbotix/lerobot@8f72211 <https://github.com/Interbotix/lerobot/commit/8f7221114505e770f1f987b6cd909e0f4a323993>`_
 
 

--- a/docs/tutorials/lerobot/changelog.rst
+++ b/docs/tutorials/lerobot/changelog.rst
@@ -23,7 +23,7 @@ Configurable Motion Timing
 
 Introduced min_time_to_move_multiplier as a configurable parameter.
 This allows users to control the time taken for the robot arm to reach a goal position via:
-`min_time_to_move = multiplier / fps`.
+``min_time_to_move = multiplier / fps``.
 
 A CLI argument can now be passed to adjust motion smoothness:
 

--- a/docs/tutorials/lerobot/replay.rst
+++ b/docs/tutorials/lerobot/replay.rst
@@ -57,6 +57,13 @@ Now try to replay the first recorded episode on your robot:
         --control.repo_id=${HF_USER}/trossen_ai_solo_test \
         --control.episode=0 \
 
+.. note::
+
+    The leader arms will be disabled in replay mode.
+
+    This change was introduced in the latest update to allow users to replay episodes or run inference
+    without requiring the leader arms to be connected or initialized. Only the follower arms are
+    needed for executing recorded trajectories or evaluating policies.
 
 Replay Configuration
 ====================

--- a/docs/tutorials/lerobot/train_and_evaluate.rst
+++ b/docs/tutorials/lerobot/train_and_evaluate.rst
@@ -176,6 +176,25 @@ Run the following command to record **10 evaluation episodes**:
    ``--robot.camera_interface='opencv'``.
    This is useful if you have configured multiple camera interfaces as explained in :ref:`tutorials/lerobot/configuration:Camera Serial Number`.
 
+.. note::
+
+    The leader arms will be disabled in evaluation mode.
+
+    This change was introduced in the latest update to allow users to replay episodes or run inference
+    without requiring the leader arms to be connected or initialized. Only the follower arms are
+    needed for executing recorded trajectories or evaluating policies.
+
+.. note::
+
+   If the arms move violently during evaluation because of the policy, you can smooth out the motion by increasing the motion duration.
+   You can do this by setting a higher multiplier using the following command-line argument:
+   ``--robot.min_time_to_move_multiplier=6.0``
+
+   This value controls the time to reach each goal as ``min_time_to_move = multiplier / fps``.
+   Lower values result in quicker but potentially jerky movement; higher values improve smoothness but increase lag.
+   A good starting value is ``3.0``.
+
+
 Key Differences from Training Data Recording
 --------------------------------------------
 


### PR DESCRIPTION
- Added a note and CLI usage example for configuring `min_time_to_move_multiplier`, allowing users to control the smoothness and responsiveness of arm motion during evaluation and inference.
- Documented the automatic disabling of leader arms during replay and evaluation, enabling users to run inference or replay episodes without requiring leader arms to be connected.
- Expanded the changelog to include these enhancements.