### PR TITLE
Add service page and guides

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ What's Here
 *   :doc:`tutorials` - Step-by-step guides for using the Trossen Arm with third party packages and frameworks.
 *   :doc:`downloads` - Downloadable content related to the Trossen Arm.
 *   :doc:`troubleshooting` - Common issues and their solutions.
+*   :doc:`service` - Information on servicing and maintaining your Trossen Arm hardware.
 *   :doc:`changelog` - Changes and updates to the Trossen Arm software.
 *   :doc:`api/library_root` - Trossen Arm API documentation.
 
@@ -31,5 +32,6 @@ Table of Contents:
     tutorials.rst
     downloads.rst
     troubleshooting.rst
+    service.rst
     changelog.rst
     api/library_root

--- a/docs/service.rst
+++ b/docs/service.rst
@@ -1,0 +1,19 @@
+=======================
+Service and Maintenance
+=======================
+
+This section provides information on how to service and maintain your Trossen Arm hardware.
+
+Cable Replacement Guides
+========================
+
+See `cable replacement guides`_ for detailed instructions on how to replace the cables in the Trossen Arm.
+
+.. _cable replacement guides: https://drive.google.com/drive/folders/1fTkOV6DC5rlOQEOLTlptDM7j4ATTRVNL
+
+Motor Replacement Guides
+========================
+
+See `motor replacement guides`_ for detailed instructions on how to replace the motors in the Trossen Arm.
+
+.. _motor replacement guides: https://drive.google.com/drive/folders/1XYWOUI-m5p2t7TWM-cbzQznoVFy23upe?usp=drive_link


### PR DESCRIPTION
This PR adds a service and maintenance page and populates it with links to the motor and cable replacement guides.