### PR TITLE
Add ROS 2 bringup demo docs

### DIFF
--- a/docs/tutorials/ros2/bringup.rst
+++ b/docs/tutorials/ros2/bringup.rst
@@ -77,11 +77,11 @@ To further customize the trossen_arm launch file at runtime, refer to the table 
 Controller Demo Script
 ----------------------
 
-A simple script is used demonstrate how to control and monitor the arm_controller and gripper_controller using their action interfaces.
+A simple script is used to demonstrate how to control and monitor the ``arm_controller`` and ``gripper_controller`` using their action interfaces.
 This script sends a series of commands to the arm and gripper, allowing you to test their functionality while printing off the action feedback and result.
 It also demonstrates handling of goal response, feedback, and results.
 
-To use this demos script, first make sure the arm and gripper controllers are running using this package's trossen_arm.launch.py launch file.
+To use this demo script, first make sure the arm and gripper controllers are running using this package's ``trossen_arm.launch.py`` launch file.
 Then run the following commands in a new terminal:
 
 .. code-block:: bash

--- a/docs/tutorials/ros2/bringup.rst
+++ b/docs/tutorials/ros2/bringup.rst
@@ -15,29 +15,37 @@ These interfaces can be swapped by changing the ``ros2_control_hardware_type`` l
 Usage
 =====
 
+Launch File
+-----------
+
+We will first cover how to launch the mock Trossen Arm hardware interface with controllers for the arm and gripper.
+
+.. code-block:: bash
+
+    source ~/ros2_ws/install/setup.bash
+    ros2 launch trossen_arm_bringup trossen_arm.launch.py ros2_control_hardware_type:=mock_components
+
+Several nodes are launched and can be listed with the following command:
+
+.. code-block:: bash
+
+    ros2 node list
+
+You will see output similar to the following:
+
+.. code-block:: console
+
+    /arm_controller
+    /controller_manager
+    /gripper_controller
+    /joint_state_broadcaster
+    /robot_state_publisher
+    /rviz2
+    /transform_listener_impl_6280570b14d0
+
 .. tabs::
 
     .. group-tab:: Humble
-
-        We will first cover how to launch the mock Trossen Arm hardware interface with controllers for the arm and gripper.
-
-        .. code-block:: bash
-
-            source ~/ros2_ws/install/setup.bash
-            ros2 launch trossen_arm_bringup trossen_arm.launch.py ros2_control_hardware_type:=mock_components
-
-        Several nodes are launched and can be listed with the following command:
-
-        .. code-block:: bash
-
-            ros2 node list
-            /arm_controller
-            /controller_manager
-            /gripper_controller
-            /joint_state_broadcaster
-            /robot_state_publisher
-            /rviz2
-            /transform_listener_impl_6280570b14d0
 
         The relevant nodes are:
 
@@ -47,26 +55,6 @@ Usage
         -   The ``joint_state_broadcaster`` is a `joint_state_broadcaster/JointStateBroadcaster <https://control.ros.org/humble/doc/ros2_controllers/joint_state_broadcaster/doc/userdoc.html>`_ node that publishes the joint states of the arm and gripper.
 
     .. group-tab:: Jazzy
-
-        We will first cover how to launch the mock Trossen Arm hardware interface with controllers for the arm and gripper.
-
-        .. code-block:: bash
-
-            source ~/ros2_ws/install/setup.bash
-            ros2 launch trossen_arm_bringup trossen_arm.launch.py ros2_control_hardware_type:=mock_components
-
-        Several nodes are launched and can be listed with the following command:
-
-        .. code-block:: bash
-
-            ros2 node list
-            /arm_controller
-            /controller_manager
-            /gripper_controller
-            /joint_state_broadcaster
-            /robot_state_publisher
-            /rviz2
-            /transform_listener_impl_6280570b14d0
 
         The relevant nodes are:
 
@@ -85,6 +73,35 @@ To further customize the trossen_arm launch file at runtime, refer to the table 
     :file: /_data/trossen_arm_bringup.csv
     :header-rows: 1
     :widths: 20, 60, 20, 20
+
+Controller Demo Script
+----------------------
+
+A simple script is used demonstrate how to control and monitor the arm_controller and gripper_controller using their action interfaces.
+This script sends a series of commands to the arm and gripper, allowing you to test their functionality while printing off the action feedback and result.
+It also demonstrates handling of goal response, feedback, and results.
+
+To use this demos script, first make sure the arm and gripper controllers are running using this package's trossen_arm.launch.py launch file.
+Then run the following commands in a new terminal:
+
+.. code-block:: bash
+
+    source ~/ros2_ws/install/setup.bash
+    ros2 run trossen_arm_bringup controllers.py
+
+You should see the arm move upright, the gripper open, the gripper close, then the arm move back to sleep.
+In the launch terminal, you will see that the arm and gripper controllers receive and respond to a series of goal requests.
+In the demo terminal, you will see feedback from both action servers, and information about goal acceptance and results.
+
+.. tabs::
+
+    .. group-tab:: Humble
+
+        See `the script source <https://github.com/TrossenRobotics/trossen_arm_ros/blob/humble/trossen_arm_bringup/demos/controllers.py>`_ for more details.
+
+    .. group-tab:: Jazzy
+
+        See `the script source <https://github.com/TrossenRobotics/trossen_arm_ros/blob/jazzy/trossen_arm_bringup/demos/controllers.py>`_ for more details.
 
 Next Steps
 ==========

--- a/docs/tutorials/ros2/moveit.rst
+++ b/docs/tutorials/ros2/moveit.rst
@@ -28,6 +28,11 @@ You can see the topics, services, and actions that are available by running:
 .. code-block:: bash
 
     ros2 node info /move_group
+
+You will see output similar to the following:
+
+.. code-block:: console
+
     /move_group
     Subscribers:
         /parameter_events: rcl_interfaces/msg/ParameterEvent


### PR DESCRIPTION
This PR adds a brief description of the bringup package's controller demo script.

It also does a bit of cleanup to remove duplicated documentation and clarify certain sections.