### PR TITLE
add build type

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,5 +14,7 @@
 
   <depend>boost</depend>
 
-  <export/>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Eliminates this warning when building with ``colcon build``:

```bash
--- stderr: libtrossen_arm
CMake Warning:
  Manually-specified variables were not used by the project:

    CATKIN_INSTALL_INTO_PREFIX_ROOT
    CATKIN_SYMLINK_INSTALL


---
Finished <<< libtrossen_arm [1.92s]
```