### PR TITLE
Update Documentation for save_interval Support in UI

### DIFF
--- a/docs/tutorials/lerobot/record_episode.rst
+++ b/docs/tutorials/lerobot/record_episode.rst
@@ -134,6 +134,12 @@ Record **2 episodes** and upload your dataset to the **Hugging Face Hub**:
    If you are using a **previous version** of the dataset, the values for joints 0-5 will be in **degrees** and a scaling of 10000 will be applied to gripper.
    Check  :ref:`tutorials/lerobot/changelog:Trossen v1.0 Dataset Format` before using datasets from previous versions.
 
+.. note::
+
+    The video encoding process can be resource-intensive.
+    This can cause longer wait times between episodes, especially if you are recording at longer episode lengths.
+    To mitigate this, consider adjusting the ``save_interval`` parameter to save data less frequently or at the end of the entire session.
+
 Handling Camera FPS Issues
 ==========================
 
@@ -303,3 +309,7 @@ When recording a dataset, you can specify command line arguments to customize th
 - ``--control.play_sounds`` (bool): Flag to use vocal synthesis to read events.
 - ``--control.resume`` (bool): Flag to resume recording on an existing dataset.
 - ``--control.local_files_only`` (bool): Flag to use local files only.
+- ``--control.save_interval`` (int): Interval in episodes at which to encode images to video and save data to disk.
+   For example, if set to 5, data will be saved every 5 episodes.
+   Default is 1 (save after every episode).
+   Setting save interval to ``-1``, ``0``, or ``> total number of episodes`` will only save data at the end of the entire data collection session.

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -248,6 +248,7 @@ An example configuration for tasks is shown below:
       push_to_hub: false
       play_sounds: true
       disable_active_ui_updates: false
+      save_interval: 1
       operators:
       - name: "YourOperator0"
         email: "youroperatoremail0@example.com"
@@ -268,6 +269,10 @@ An example configuration for tasks is shown below:
 - ``push_to_hub``: Boolean flag indicating whether to push the collected data to the Hugging Face Hub.
 - ``play_sounds``: Boolean flag indicating whether to play sounds during the task.
 - ``disable_active_ui_updates``: Boolean flag to disable active UI updates during the task.
+- ``save_interval``: Interval in episodes at which to encode images to video and save data to disk.
+  For example, if set to 5, data will be saved every 5 episodes.
+  Default is 1 (save after every episode).
+  Setting save interval to ``-1``, ``0``, or ``> total number of episodes`` will only save data at the end of the entire data collection session.
 - ``operators``: Optional list of operators involved in the task.
   The operator information will be saved in ``info.json`` in the metadata folder.
   You can add multiple operators by specifying their names and email addresses.
@@ -280,6 +285,12 @@ An example configuration for tasks is shown below:
 
     If you choose to push data to the Hugging Face Hub, ensure that you have an account and have set up the necessary authentication.
     Check out the :ref:`tutorials/lerobot/record_episode:Logging into Hugging Face` for more details on generating and using access tokens.
+
+.. note::
+
+    The video encoding process can be resource-intensive.
+    This can cause longer wait times between episodes, especially if you are recording at longer episode lengths.
+    To mitigate this, consider adjusting the ``save_interval`` parameter to save data less frequently or at the end of the entire session.
 
 Application Features
 ====================


### PR DESCRIPTION
This PR updates the documentation to explain the new `save_interval` feature now supported through the UI.

Key points:

* `save_interval` can be defined in `tasks.yaml` to control how frequently episodes are encoded and saved.
* Default behavior is `save_interval: 1` (encode after each episode).
* Setting `save_interval` to `-1`, `0`, or a value greater than total episodes defers encoding until the end of the recording session.
* Users can also configure batch encoding directly through the UI without using the `--control.save_interval` flag.

