### PR TITLE
docs: add section for  GPU video encoding features

### DIFF
--- a/docs/tutorials/lerobot/record_episode.rst
+++ b/docs/tutorials/lerobot/record_episode.rst
@@ -341,7 +341,7 @@ Experimental Feature
 
     The GOP (Group of Pictures) size for video encoding can be adjusted by setting the ``LEROBOT_GOP_SIZE`` environment variable (default is 30).
     A smaller GOP size can lead to better video quality but may increase file size.
-    GPU encoding requires a the GOP size to be a multiple of the FPS.
+    GPU encoding requires the GOP size to be a multiple of the FPS.
 
     .. code-block:: bash
 

--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -319,7 +319,7 @@ Experimental Features
 
     The GOP (Group of Pictures) size for video encoding can be adjusted by setting the ``LEROBOT_GOP_SIZE`` environment variable (default is 30).
     A smaller GOP size can lead to better video quality but may increase file size.
-    GPU encoding requires a the GOP size to be a multiple of the FPS.
+    GPU encoding requires the GOP size to be a multiple of the FPS.
 
     .. code-block:: bash
 


### PR DESCRIPTION
Added documentation for experimental GPU video encoding support.

- Introduced "Experimental Features" section.
- Described environment variables:
  - LEROBOT_GPU_ENCODING
  - LEROBOT_GPU_ID
  - LEROBOT_GOP_SIZE
- Included usage examples and setup notes for NVIDIA GPUs.
