### PR TITLE
updated openpi docs

### DIFF
--- a/docs/tutorials/openpi.rst
+++ b/docs/tutorials/openpi.rst
@@ -104,7 +104,11 @@ Here is a recorded dataset using the above instructions:
 
 - `Bimanual WidowX-AI Handover Cube <https://huggingface.co/datasets/TrossenRoboticsCommunity/bimanual-widowxai-handover-cube>`_
 
-You can also visualize the dataset using the following link. Just paste the dataset name here:
+You can also visualize the dataset using the following link. Just paste the dataset name in the input box.
+
+- Visualize using `the HuggingFace visualize_dataset space <https://huggingface.co/spaces/lerobot/visualize_dataset>`
+
+Or you can also visualize it locally using LeRobot:
 
 - Visualize using :ref:`tutorials/lerobot_plugin/visualize:Visualize`
 


### PR DESCRIPTION
Updated openpi documentation.

### What changed

- Updated LeRobot references from the deprecated `TrossenRobotics/lerobot_trossen` to the current `Interbotix/lerobot`
- Replaced internal documentation links with direct external links to Trossen Robotics documentation
- Updated dataset visualization instructions to use the HuggingFace space
- Restructured the training section to emphasize the requirement for custom configurations
- Added clearer section headers and improved instructions for creating custom training configurations
- Added explicit instructions on how to run the training command with custom configurations
