### PR TITLE
Update lerobot fork note

### DIFF
--- a/docs/tutorials/lerobot.rst
+++ b/docs/tutorials/lerobot.rst
@@ -1,11 +1,13 @@
-=========================
-LeRobot Fork (Deprecated)
-=========================
+============
+LeRobot Fork
+============
 
-.. warning::
+.. note::
 
-    Support for the fork-based LeRobot integration has been deprecated.
+    Ongoing support for the LeRobot fork is deprecated.
     We recommend using the :doc:`plugin-based LeRobot integration <./lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <./openpi>`.
 
 This page contains tutorials for using the Trossen AI Kits with LeRobot for data collection and imitation learning.
 

--- a/docs/tutorials/lerobot/configuration.rst
+++ b/docs/tutorials/lerobot/configuration.rst
@@ -2,10 +2,12 @@
 Trossen AI Configuration
 ========================
 
-.. warning::
+.. note::
 
-    Support for the fork-based LeRobot integration has been deprecated.
+    Ongoing support for the LeRobot fork is deprecated.
     We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
 
 In order to use the Trossen AI Kits with LeRobot, you need to first configure the arms with the necessary specifications.
 The specifications include the IP address, model_name, and camera serial numbers.

--- a/docs/tutorials/lerobot/record_episode.rst
+++ b/docs/tutorials/lerobot/record_episode.rst
@@ -2,10 +2,12 @@
 Record Episodes
 ===============
 
-.. warning::
+.. note::
 
-    Support for the fork-based LeRobot integration has been deprecated.
+    Ongoing support for the LeRobot fork is deprecated.
     We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
 
 Once you're familiar with teleoperation, you can record your first dataset.
 

--- a/docs/tutorials/lerobot/replay.rst
+++ b/docs/tutorials/lerobot/replay.rst
@@ -2,6 +2,13 @@
 Replaying an Episode
 ====================
 
+.. note::
+
+    Ongoing support for the LeRobot fork is deprecated.
+    We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
+
 .. warning::
 
     We have introduced a new change in how the values are saved in the dataset.

--- a/docs/tutorials/lerobot/setup.rst
+++ b/docs/tutorials/lerobot/setup.rst
@@ -2,6 +2,13 @@
 LeRobot Installation Guide
 ==========================
 
+.. note::
+
+    Ongoing support for the LeRobot fork is deprecated.
+    We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
+
 Install LeRobot
 ===============
 

--- a/docs/tutorials/lerobot/teleoperation.rst
+++ b/docs/tutorials/lerobot/teleoperation.rst
@@ -2,6 +2,13 @@
 Teleoperation
 =============
 
+.. note::
+
+    Ongoing support for the LeRobot fork is deprecated.
+    We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
+
 By running the following code, you can start your first **SAFE** teleoperation:
 
 .. tabs::

--- a/docs/tutorials/lerobot/train_and_evaluate.rst
+++ b/docs/tutorials/lerobot/train_and_evaluate.rst
@@ -2,6 +2,13 @@
 Training and Evaluating a Policy
 ================================
 
+.. note::
+
+    Ongoing support for the LeRobot fork is deprecated.
+    We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
+
 .. warning::
 
     We have introduced a new change in how the values are saved in the dataset.

--- a/docs/tutorials/lerobot/visualize.rst
+++ b/docs/tutorials/lerobot/visualize.rst
@@ -2,6 +2,13 @@
 Visualize
 =========
 
+.. note::
+
+    Ongoing support for the LeRobot fork is deprecated.
+    We recommend using the :doc:`plugin-based LeRobot integration <../lerobot_plugin>` instead.
+
+    However, this integration is necessary for users who wish to use the :doc:`openpi integration <../openpi>`.
+
 Remote Visualization
 ====================
 


### PR DESCRIPTION
This PR modified the LeRobot fork deprecation notice to be more explicit about compatibility with openpi.