### PR TITLE
docs: update gripper unit from mm to meters

### DIFF
--- a/docs/tutorials/lerobot/record_episode.rst
+++ b/docs/tutorials/lerobot/record_episode.rst
@@ -131,7 +131,7 @@ Record two episodes and upload your dataset to the Hugging Face Hub:
     The units for each joint are as follows:
 
     - **Joints 0-5**: Radians
-    - **Joint 6 (Gripper)**: Millimeters (mm)
+    - **Joint 6 (Gripper)**: Meters (m)
 
 .. warning::
 


### PR DESCRIPTION
Updated the unit for Joint 6 (Gripper) from millimeters to meters in the documentation.