### PR TITLE
docs: add SLATE mobile base setup instructions

### DIFF
--- a/docs/tutorials/lerobot/setup.rst
+++ b/docs/tutorials/lerobot/setup.rst
@@ -88,3 +88,21 @@ On your computer:
         .. code-block:: bash
 
             which ffmpeg
+
+#. For Trossen AI Mobile only, configure the SLATE mobile base:
+
+    The SLATE mobile base uses a USB-Serial converter to communicate with the host computer.
+
+    Remove ``brltty`` to prevent it from claiming the device:
+
+    .. code-block:: bash
+
+        sudo apt-get remove brltty
+
+    Add your user to the ``dialout`` group:
+
+    .. code-block:: bash
+
+        sudo usermod -a -G dialout $USER
+
+    Log out and log back in, or reboot your computer to apply the changes.


### PR DESCRIPTION
### TL;DR

Added configuration steps for the SLATE mobile base in the setup documentation.