### PR TITLE
Final Cleanup

### DIFF
--- a/docs/tutorials/trossen_data_collection_ui.rst
+++ b/docs/tutorials/trossen_data_collection_ui.rst
@@ -100,7 +100,7 @@ Once the desktop icon is created, right-click on it and select **Allow Launching
 
 .. note::
 
-    **Touchscreen Interface Setup**: If you plan to use a touchscreen display with the Trossen AI Data Collection UI, refer to the :doc:`touchscreen_setup` guide for complete hardware setup, cable connections, and touchscreen mapping configuration.
+    **Touchscreen Interface Setup**: If you plan to use a touchscreen display with the Trossen AI Data Collection UI, refer to the :doc:`../getting_started/touchscreen` guide for complete hardware setup, cable connections, and touchscreen mapping configuration.
 
 Launching the Application
 =========================


### PR DESCRIPTION
### TL;DR

Updated documentation links for touchscreen setup guide.

### What changed?

- Removed `tutorials/touchscreen_setup.rst` from the tutorials table of contents
- Updated the reference link in the touchscreen note to point to `../getting_started/touchscreen` instead of `touchscreen_setup`
