### PR TITLE
Clarify the tutorials entry in the docs index

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,8 +1,0 @@
-=========
-Community
-=========
-
-Overview
-========
-
-This section is dedicated to showcasing integrations and highlights from users of Trossen robots.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,8 +18,7 @@ What's Here
 
 *   :doc:`specifications` - Contains specification information for the Trossen Arms and related hardware.
 *   :doc:`getting_started` - These guides will walk you through the setup process for your Trossen Arm.
-*   :doc:`tutorials` - Step-by-step guides for using the Trossen Arm with third party packages and frameworks.
-*   :doc:`community` - Showcase for community highlights and integrations.
+*   :doc:`tutorials` - Step-by-step guides for using the Trossen Arm with third party packages and frameworks like ROS 2 and LeRobot.
 *   :doc:`downloads` - Downloadable content related to the Trossen Arm.
 *   :doc:`troubleshooting` - Common issues and their solutions.
 *   :doc:`service` - Information on servicing and maintaining your Trossen Arm hardware.


### PR DESCRIPTION
This PR does the following:
- Clarifies that the tutorials section contains guides for ROS 2 and LeRobot
- Removes the unused community section