### PR TITLE
Add LeRobot async inference and project integration guides

### DIFF
--- a/docs/tutorials/lerobot_plugin.rst
+++ b/docs/tutorials/lerobot_plugin.rst
@@ -9,9 +9,11 @@ This page contains tutorials for using the Trossen AI Kits with the LeRobot "bri
     :caption: Contents:
 
     lerobot_plugin/setup.rst
+    lerobot_plugin/use_in_your_project.rst
     lerobot_plugin/configuration.rst
     lerobot_plugin/teleoperation.rst
     lerobot_plugin/record_episode.rst
     lerobot_plugin/visualize.rst
     lerobot_plugin/replay.rst
     lerobot_plugin/train_and_evaluate.rst
+    lerobot_plugin/async_inference.rst

--- a/docs/tutorials/lerobot_plugin/async_inference.rst
+++ b/docs/tutorials/lerobot_plugin/async_inference.rst
@@ -1,0 +1,76 @@
+===============
+Async Inference
+===============
+
+For asynchronous / distributed inference, LeRobot runs the policy in a separate **policy server** process and the robot in a **client** process, communicating over gRPC.
+This is the recommended path for slow VLA policies (π₀, π₀.₅, SmolVLA): the client keeps the robot control loop responsive while the server runs inference, and overlapping action chunks are blended on the client (real-time chunking).
+
+Dependencies
+============
+
+The server and client live in **upstream LeRobot**, and they need dependencies the lean base install (:doc:`setup`) omits:
+
+- ``async`` — the ``grpcio`` transport used between the server and client.
+- ``pi`` — ``transformers``/``peft``, required for the π-family policies.
+
+If you cloned and synced ``lerobot_trossen``, layer these in at run time by prefixing the command with ``uv run --with "lerobot[async,pi]>=0.5.1"`` (requires Python ≥ 3.12).
+If you consume the packages from :doc:`use_in_your_project` and declared the ``async`` / ``pi`` extras there, omit the ``--with`` prefix and run the modules directly.
+
+Running the Policy Server and Robot Client
+==========================================
+
+The flow uses two processes.
+Start the policy server first, then the robot client.
+
+#. Start the policy server (Terminal A).
+
+    The policy server holds the policy on the GPU and answers inference requests:
+
+    .. code-block:: bash
+
+        uv run --with "lerobot[async,pi]>=0.5.1" python -m lerobot.async_inference.policy_server \
+            --host=127.0.0.1 \
+            --port=8080 \
+            --fps=30 \
+            --inference_latency=0.033 \
+            --obs_queue_timeout=2
+
+#. Start the robot client (Terminal B).
+
+    The robot client drives the hardware and streams observations to the server.
+    The example below is for a Trossen AI Stationary (bimanual) kit; adapt ``--robot.type`` and the camera/IP arguments for your kit:
+
+    .. code-block:: bash
+
+        uv run --with "lerobot[async,pi]>=0.5.1" python -m lerobot.async_inference.robot_client \
+            --server_address=127.0.0.1:8080 \
+            --robot.type=bi_widowxai_follower_robot \
+            --robot.left_arm_ip_address=192.168.1.5 \
+            --robot.right_arm_ip_address=192.168.1.4 \
+            --robot.left_arm_max_relative_target=0.5 \
+            --robot.right_arm_max_relative_target=0.5 \
+            --robot.id=bimanual_follower \
+            --robot.cameras='{
+                cam_high: {type: intelrealsense, serial_number_or_name: "0123456789", width: 640, height: 480, fps: 30},
+                cam_low: {type: intelrealsense, serial_number_or_name: "0123456789", width: 640, height: 480, fps: 30},
+                cam_left_wrist: {type: intelrealsense, serial_number_or_name: "0123456789", width: 640, height: 480, fps: 30},
+                cam_right_wrist: {type: intelrealsense, serial_number_or_name: "0123456789", width: 640, height: 480, fps: 30}
+                }' \
+            --task="Grab and handover the red cube to the other arm" \
+            --policy_type=pi05 \
+            --pretrained_name_or_path=${HF_USER}/pi05-block-transfer-lerobot \
+            --policy_device=cuda \
+            --actions_per_chunk=50 \
+            --chunk_size_threshold=0.5 \
+            --aggregate_fn_name=weighted_average
+
+Notes
+=====
+
+- The Trossen robots **auto-register** — LeRobot discovers the installed ``lerobot_robot_trossen`` plugin, so ``--robot.type=bi_widowxai_follower_robot`` resolves with no manual import.
+- The model loads on the **first** client connection (large VLAs take 1–2 min) before the first action is produced.
+- The ``--task`` prompt **must match training** (π-family policies are language-conditioned).
+- ``--actions_per_chunk``, ``--chunk_size_threshold``, and ``--aggregate_fn_name`` control real-time chunking: how many predicted steps to execute per chunk, when to re-query the server, and how overlapping steps are blended (``weighted_average``).
+- The client strictly only needs ``lerobot[async]``; using ``[async,pi]`` on both is identical and simplest.
+- Start with conservative ``--robot.*_max_relative_target`` caps and keep an e-stop within reach; remove the caps once you trust the motion.
+- Stop the **client** first (``Ctrl-C``), then the server.

--- a/docs/tutorials/lerobot_plugin/async_inference.rst
+++ b/docs/tutorials/lerobot_plugin/async_inference.rst
@@ -11,10 +11,12 @@ Dependencies
 The server and client live in **upstream LeRobot**, and they need dependencies the lean base install (:doc:`setup`) omits:
 
 - ``async`` — the ``grpcio`` transport used between the server and client.
-- ``pi`` — ``transformers``/``peft``, required for the π-family policies.
+- ``pi`` — ``transformers``/``peft``, required for the π-family policies (π₀, π₀.₅).
+- ``smolvla`` — required for SmolVLA policies.
 
-If you cloned and synced ``lerobot_trossen``, layer these in at run time by prefixing the command with ``uv run --with "lerobot[async,pi]>=0.5.1"`` (requires Python ≥ 3.12).
-If you consume the packages from :doc:`use_in_your_project` and declared the ``async`` / ``pi`` extras there, omit the ``--with`` prefix and run the modules directly.
+Pick the policy extra that matches your policy family: ``pi`` for the π-family, ``smolvla`` for SmolVLA.
+If you cloned and synced ``lerobot_trossen``, layer these in at run time by prefixing the command with ``uv run --with "lerobot[async,pi]>=0.5.1"`` (swap ``pi`` for ``smolvla`` when serving SmolVLA; requires Python ≥ 3.12).
+If you consume the packages from :doc:`use_in_your_project` and declared the ``async`` / ``pi`` / ``smolvla`` extras there, omit the ``--with`` prefix and run the modules directly.
 
 Running the Policy Server and Robot Client
 ==========================================

--- a/docs/tutorials/lerobot_plugin/async_inference.rst
+++ b/docs/tutorials/lerobot_plugin/async_inference.rst
@@ -10,9 +10,9 @@ Dependencies
 
 The server and client live in **upstream LeRobot**, and they need dependencies the lean base install (:doc:`setup`) omits:
 
-- ``async`` — the ``grpcio`` transport used between the server and client.
-- ``pi`` — ``transformers``/``peft``, required for the π-family policies (π₀, π₀.₅).
-- ``smolvla`` — required for SmolVLA policies.
+- ``async``: the ``grpcio`` transport used between the server and client.
+- ``pi``: ``transformers``/``peft``, required for the π-family policies (π₀, π₀.₅).
+- ``smolvla``: required for SmolVLA policies.
 
 Pick the policy extra that matches your policy family: ``pi`` for the π-family, ``smolvla`` for SmolVLA.
 If you cloned and synced ``lerobot_trossen``, layer these in at run time by prefixing the command with ``uv run --with "lerobot[async,pi]>=0.5.1"`` (swap ``pi`` for ``smolvla`` when serving SmolVLA; requires Python ≥ 3.12).
@@ -69,7 +69,7 @@ Start the policy server first, then the robot client.
 Notes
 =====
 
-- The Trossen robots **auto-register** — LeRobot discovers the installed ``lerobot_robot_trossen`` plugin, so ``--robot.type=bi_widowxai_follower_robot`` resolves with no manual import.
+- The Trossen robots **auto-register**: LeRobot discovers the installed ``lerobot_robot_trossen`` plugin, so ``--robot.type=bi_widowxai_follower_robot`` resolves with no manual import.
 - The model loads on the **first** client connection (large VLAs take 1–2 min) before the first action is produced.
 - The ``--task`` prompt **must match training** (π-family policies are language-conditioned).
 - ``--actions_per_chunk``, ``--chunk_size_threshold``, and ``--aggregate_fn_name`` control real-time chunking: how many predicted steps to execute per chunk, when to re-query the server, and how overlapping steps are blended (``weighted_average``).

--- a/docs/tutorials/lerobot_plugin/setup.rst
+++ b/docs/tutorials/lerobot_plugin/setup.rst
@@ -5,6 +5,11 @@ LeRobot Installation Guide
 Install LeRobot
 ===============
 
+.. note::
+
+    This package requires **Python ≥ 3.12** (it depends on ``lerobot >= 0.5.1``, which requires 3.12).
+    ``uv`` provisions a compatible interpreter automatically, so no manual Python setup is needed.
+
 On your computer:
 
 #. Install uv:

--- a/docs/tutorials/lerobot_plugin/setup.rst
+++ b/docs/tutorials/lerobot_plugin/setup.rst
@@ -7,7 +7,7 @@ Install LeRobot
 
 .. note::
 
-    This package requires **Python ≥ 3.12** (it depends on ``lerobot >= 0.5.1``, which requires 3.12).
+    This package requires **Python ≥ 3.12** (it depends on ``lerobot >= 0.5.1``).
     ``uv`` provisions a compatible interpreter automatically, so no manual Python setup is needed.
 
 On your computer:

--- a/docs/tutorials/lerobot_plugin/train_and_evaluate.rst
+++ b/docs/tutorials/lerobot_plugin/train_and_evaluate.rst
@@ -199,7 +199,7 @@ Evaluating VLA Policies
 The examples above evaluate an **ACT** policy, which the lean base install (:doc:`setup`) runs directly.
 **VLA policies (π₀, π₀.₅, SmolVLA) need extra dependencies** (``transformers``/``peft``) that the base install omits.
 
-If you cloned and synced ``lerobot_trossen``, layer the extra at run time by prefixing the command with ``uv run --with "lerobot[pi]>=0.5.1"`` (use ``[smolvla]`` for SmolVLA):
+If you cloned and synced ``lerobot_trossen``, layer the extras at run time by prefixing the command with ``uv run --with "lerobot[pi]>=0.5.1"`` (use ``[smolvla]`` for SmolVLA):
 
 .. code-block:: bash
 

--- a/docs/tutorials/lerobot_plugin/train_and_evaluate.rst
+++ b/docs/tutorials/lerobot_plugin/train_and_evaluate.rst
@@ -192,3 +192,32 @@ Key Differences from Training Data Recording
     - We set ``--num_image_writer_processes=1`` instead of the default ``0``.
     - On some systems, using a dedicated process for writing images (from multiple cameras) allows achieving a consistent 30 FPS during inference.
     - You can experiment with different values of ``--num_image_writer_processes`` to optimize performance.
+
+Evaluating VLA Policies
+=======================
+
+The examples above evaluate an **ACT** policy, which the lean base install (:doc:`setup`) runs directly.
+**VLA policies (π₀, π₀.₅, SmolVLA) need extra dependencies** (``transformers``/``peft``) that the base install omits.
+
+If you cloned and synced ``lerobot_trossen``, layer the extra at run time by prefixing the command with ``uv run --with "lerobot[pi]>=0.5.1"`` (use ``[smolvla]`` for SmolVLA):
+
+.. code-block:: bash
+
+    uv run --with "lerobot[pi]>=0.5.1" lerobot-record \
+        --robot.type=widowxai_follower_robot \
+        --robot.ip_address=192.168.1.4 \
+        --robot.id=follower \
+        --robot.cameras='{
+            cam_main: {type: intelrealsense, serial_number_or_name: "0123456789", width: 640, height: 480, fps: 30}
+            }' \
+        --display_data=false \
+        --dataset.repo_id=${HF_USER}/eval_trossen_ai_solo_test \
+        --dataset.single_task="Grab the cube" \
+        --policy.path=${HF_USER}/my_pi05_policy
+
+If you use your own project (:doc:`use_in_your_project`) and declared the ``pi`` / ``smolvla`` extras there, omit the ``--with "lerobot[pi]>=0.5.1"`` prefix and run ``lerobot-record`` directly.
+
+.. note::
+
+    Synchronous evaluation with ``lerobot-record`` runs the policy in the robot control loop, which large VLAs are often too slow for.
+    For responsive on-robot VLA evaluation, prefer the :doc:`async_inference` flow, which runs the policy in a separate server process.

--- a/docs/tutorials/lerobot_plugin/use_in_your_project.rst
+++ b/docs/tutorials/lerobot_plugin/use_in_your_project.rst
@@ -1,4 +1,3 @@
-
 =======================
 Use in Your Own Project
 =======================
@@ -15,8 +14,8 @@ The Packages
 
 ``lerobot_trossen`` is a ``uv`` workspace that publishes two plugin packages:
 
-- ``lerobot-robot-trossen`` — the follower-robot plugin (registers the ``widowxai_follower_robot``, ``bi_widowxai_follower_robot``, and ``mobileai_robot`` robot types).
-- ``lerobot-teleoperator-trossen`` — the leader / teleoperator plugin.
+- ``lerobot-robot-trossen``: the follower-robot plugin (registers the ``widowxai_follower_robot``, ``bi_widowxai_follower_robot``, and ``mobileai_robot`` robot types).
+- ``lerobot-teleoperator-trossen``: the leader / teleoperator plugin.
 
 Both require **Python ≥ 3.12** (they depend on ``lerobot >= 0.5.1``).
 They are not published to PyPI, so depend on them directly from Git.
@@ -96,13 +95,13 @@ Or in ``pyproject.toml``:
 
 .. note::
 
-    Only declare the extras you actually use — each one adds significant install size.
+    Only declare the extras you actually use; each one adds significant install size.
     If you only run ACT policies, the base plugin dependencies are enough and you can skip this section entirely.
 
 Running Commands
 ================
 
-With the dependencies declared, run the LeRobot entry points directly through your project's environment — no ``--with`` prefix:
+With the dependencies declared, run the LeRobot entry points directly through your project's environment, with no ``--with`` prefix:
 
 .. code-block:: bash
 

--- a/docs/tutorials/lerobot_plugin/use_in_your_project.rst
+++ b/docs/tutorials/lerobot_plugin/use_in_your_project.rst
@@ -1,0 +1,122 @@
+
+=======================
+Use in Your Own Project
+=======================
+
+The :doc:`setup` guide clones ``lerobot_trossen`` and runs the commands from inside that checkout.
+That is the quickest way to get going, but if you are building your own application you usually want the Trossen LeRobot plugins as **dependencies of your own project** instead.
+This lets you control your own environment, pin your own versions, and decide up front which policy families to install.
+
+This page shows how to depend on the Trossen plugin packages.
+It also shows how to bake in the LeRobot extras (``pi``, ``smolvla``, ``async``) so you never need the ``uv run --with`` prefix at run time.
+
+The Packages
+============
+
+``lerobot_trossen`` is a ``uv`` workspace that publishes two plugin packages:
+
+- ``lerobot-robot-trossen`` — the follower-robot plugin (registers the ``widowxai_follower_robot``, ``bi_widowxai_follower_robot``, and ``mobileai_robot`` robot types).
+- ``lerobot-teleoperator-trossen`` — the leader / teleoperator plugin.
+
+Both require **Python ≥ 3.12** (they depend on ``lerobot >= 0.5.1``).
+They are not published to PyPI, so depend on them directly from Git.
+
+Add the Dependencies
+====================
+
+#. Add the plugin packages from the ``lerobot_trossen`` repository.
+
+    Each package lives in its own subdirectory of the workspace:
+
+    .. code-block:: bash
+
+        uv add "lerobot-robot-trossen @ git+https://github.com/TrossenRobotics/lerobot_trossen.git#subdirectory=packages/lerobot_robot_trossen"
+        uv add "lerobot-teleoperator-trossen @ git+https://github.com/TrossenRobotics/lerobot_trossen.git#subdirectory=packages/lerobot_teleoperator_trossen"
+
+    Equivalently, declare them in your ``pyproject.toml``:
+
+    .. code-block:: toml
+
+        [project]
+        requires-python = ">=3.12"
+        dependencies = [
+            "lerobot-robot-trossen",
+            "lerobot-teleoperator-trossen",
+        ]
+
+        [tool.uv.sources]
+        lerobot-robot-trossen = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git", subdirectory = "packages/lerobot_robot_trossen" }
+        lerobot-teleoperator-trossen = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git", subdirectory = "packages/lerobot_teleoperator_trossen" }
+
+#. Resolve and install:
+
+    .. code-block:: bash
+
+        uv sync
+
+Declaring Policy Extras
+=======================
+
+The plugin packages pull in a **lean** LeRobot install.
+This is enough to teleoperate, record, replay, and run ACT policies, but without the heavier optional stacks.
+VLA policies and async inference need additional LeRobot extras:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 20 80
+
+    * - Extra
+      - Needed for
+    * - ``pi``
+      - π₀ / π₀.₅ policies (pulls in ``transformers`` / ``peft``)
+    * - ``smolvla``
+      - SmolVLA policies
+    * - ``async``
+      - :doc:`async_inference` (the ``grpcio`` policy-server / robot-client transport)
+
+When you work from a clone of ``lerobot_trossen``, these are layered in per command with ``uv run --with "lerobot[pi]>=0.5.1"``.
+In your own project you can instead declare them once, so they are always installed and the ``--with`` prefix is no longer needed.
+
+Add the extras alongside the plugin packages:
+
+.. code-block:: bash
+
+    uv add "lerobot[pi,smolvla,async]>=0.5.1"
+
+Or in ``pyproject.toml``:
+
+.. code-block:: toml
+
+    [project]
+    dependencies = [
+        "lerobot-robot-trossen",
+        "lerobot-teleoperator-trossen",
+        "lerobot[pi,smolvla,async]>=0.5.1",
+    ]
+
+.. note::
+
+    Only declare the extras you actually use — each one adds significant install size.
+    If you only run ACT policies, the base plugin dependencies are enough and you can skip this section entirely.
+
+Running Commands
+================
+
+With the dependencies declared, run the LeRobot entry points directly through your project's environment — no ``--with`` prefix:
+
+.. code-block:: bash
+
+    uv run lerobot-record \
+        --robot.type=widowxai_follower_robot \
+        --robot.ip_address=192.168.1.4 \
+        --robot.id=follower \
+        --robot.cameras='{
+            cam_main: {type: intelrealsense, serial_number_or_name: "0123456789", width: 640, height: 480, fps: 30}
+            }' \
+        --display_data=false \
+        --dataset.repo_id=${HF_USER}/eval_trossen_ai_solo_test \
+        --dataset.single_task="Grab the cube" \
+        --policy.path=${HF_USER}/my_pi05_policy
+
+See :doc:`train_and_evaluate` for the full evaluation workflow.
+See :doc:`async_inference` for the policy-server / robot-client flow.


### PR DESCRIPTION
## Summary

Adds documentation for the LeRobot plugin covering async inference and consuming the Trossen LeRobot plugins as dependencies.

- Documents the **policy-server / robot-client async inference flow** (`async_inference.rst`).
- Explains how to **consume the Trossen LeRobot plugins as dependencies** in your own project (`use_in_your_project.rst`).
- Notes the **Python 3.12 / lerobot 0.5.1** requirement and how to layer the `pi` / `smolvla` / `async` extras for VLA evaluation.
- Minor additions to `setup.rst`, `train_and_evaluate.rst`, and the plugin index.

## Files

- `docs/tutorials/lerobot_plugin/async_inference.rst` (new)
- `docs/tutorials/lerobot_plugin/use_in_your_project.rst` (new)
- `docs/tutorials/lerobot_plugin/setup.rst`
- `docs/tutorials/lerobot_plugin/train_and_evaluate.rst`
- `docs/tutorials/lerobot_plugin.rst`

