### PR TITLE
seo: Resolve duplicate titles and version ambiguity via layout.html templates

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,4 +1,22 @@
-{% extends "!layout.html" %}
+{%- extends "!layout.html" %}
+
+{# 1. Override the title block to dynamically append the active version/branch name #}
+{%- block htmltitle %}
+  {% if current_version %}
+    <title>{{ title|striptags|e }} ({{ current_version.name }}) — {{ project }}</title>
+  {% else %}
+    <title>{{ title|striptags|e }} — {{ project }}</title>
+  {% endif %}
+{%- endblock %}
+
+{# 2. Override linktags to force canonical link of historical versions to the maintained v1.9 version #}
+{%- block linktags %}
+  {{ super() }}
+  {% if current_version %}
+    <link rel="canonical" href="https://docs.trossenrobotics.com/trossen_arm/v1.9/{{ pagename }}.html" />
+  {% endif %}
+{%- endblock %}
+
 {%- block sidebartitle %}
   <div class="sidebartitle-docs-home">
     <a href="https://docs.trossenrobotics.com/" target="_blank" class="icon icon-home">


### PR DESCRIPTION
## Summary
This PR resolves the duplicate documentation titles and version ambiguity across docs.trossenrobotics.com as identified in the Technical SEO audit.

## Changes
1. **docs/_templates/layout.html**:
   - Overrode the `htmltitle` block to dynamically append the active version/branch name to the title tag when `current_version` is present (e.g. `Replaying an Episode (v1.9) — Trossen Robotics Trossen Arm Documentation`).
   - Overrode the `linktags` block to configure standard `<link rel="canonical">` meta tags that canonicalize historical/development versions to the latest stable maintained version (`v1.9`), resolving index bloat and search cannibalization while preserving user accessibility.